### PR TITLE
Ruby version upgrade to deploy on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Rails - 6.1.4
-Ruby - 2.5.1
+Ruby - 2.7.2
 Front end - Bootstrap
 Authentication - Devise
 


### PR DESCRIPTION
- upgraded Ruby to 2.7.2, Heroku supports Ruby 2.7 and above only. 